### PR TITLE
Mobile numbers issue fixed for indian numbers

### DIFF
--- a/Rest-API/main.py
+++ b/Rest-API/main.py
@@ -116,7 +116,7 @@ async def generate_data():
             "name": (name := fake.name()),
             "city": fake.city(),
             "email": name.lower().replace(" ", "") + "@" + random.choice(["yahoo.com", "gmail.com", "outlook.com"]),
-            "phone_number": fake.phone_number(),
+            "phone_number": str(random.choice([6, 7, 8, 9])) + ''.join(str(random.randint(0, 9)) for _ in range(9)),
         }
         for customer_id in customer_ids
     ]


### PR DESCRIPTION
There is an issue in the Suppliers API and Customers API where mobile number validation is not enforcing the correct format. As per the requirement, the mobile number should:

Start with digits 6, 7, 8, or 9

Contain exactly 10 digits

Currently, the Suppliers / Customers API is allowing invalid mobile numbers that do not meet these criteria. Now it is fixed