### PR TITLE
Feature/Changing credentials as of latest GCP

### DIFF
--- a/ETL-Airflow/dags/tasks/ingestion_tasks.py
+++ b/ETL-Airflow/dags/tasks/ingestion_tasks.py
@@ -164,7 +164,7 @@ def sales_data_ingestion():
     spark = get_spark_session()
 
     # Create a data frame by reading the CSV from the Google Bucket
-    sales_df = spark.read.csv(f'gs://meta-morph/{today}/sales_{today}.csv', header=True, inferSchema=True)
+    sales_df = spark.read.csv(f'gs://meta-morph-flow/{today}/sales_{today}.csv', header=True, inferSchema=True)
     logging.info("Data Frame : 'sales_df' is built")
     
     api = "sales"

--- a/ETL-Airflow/dags/tasks/m_customer_sales_report_task.py
+++ b/ETL-Airflow/dags/tasks/m_customer_sales_report_task.py
@@ -206,7 +206,7 @@ def customer_sales_report_ingestion():
         
         # Load the Data into Parquet File
         logging.info("Authenticating to GCS to load the data into parquet file..")
-        Shortcut_To_Customer_Sales_Report_Tgt.write.mode("append").parquet("gs://reporting-legacy/customer_sales_report")
+        Shortcut_To_Customer_Sales_Report_Tgt.write.mode("append").parquet("gs://reporting-lgcy/customer_sales_report")
         logging.info(f"Loaded into Parquet File : customer_sales_report")
 
         # Load the data into the table

--- a/ETL-Airflow/dags/tasks/m_product_performance_task.py
+++ b/ETL-Airflow/dags/tasks/m_product_performance_task.py
@@ -126,7 +126,7 @@ def product_performance_ingestion():
         
         # Load the Data into Parquet File
         logging.info("Authenticating to GCS to load the data into parquet file..")
-        Shortcut_To_Products_Performance_tgt.write.mode("append").parquet("gs://reporting-legacy/product_performance")
+        Shortcut_To_Products_Performance_tgt.write.mode("append").parquet("gs://reporting-lgcy/product_performance")
         logging.info(f"Loaded into Parquet File : product_performance")
 
         # Load the data into the table

--- a/ETL-Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL-Airflow/dags/tasks/m_supplier_performance_task.py
@@ -131,7 +131,7 @@ def suppliers_performance_ingestion():
         
         # Load the Data into Parquet File
         logging.info("Authenticating to GCS to load the data into parquet file..")
-        Shortcut_To_Suppliers_Performance_tgt.write.mode("append").parquet("gs://reporting-legacy/supplier_performance")
+        Shortcut_To_Suppliers_Performance_tgt.write.mode("append").parquet("gs://reporting-lgcy/supplier_performance")
         logging.info(f"Loaded into Parquet File : supplier_performance")
 
         # Load the data into the table

--- a/Rest-API/main.py
+++ b/Rest-API/main.py
@@ -57,7 +57,7 @@ async def gs_bucket_auth_save(sample, type_of_data):
 
     # Upload the content of BytesIO object to GCS
     storage_client = storage.Client.from_service_account_json(SERVICE_KEY)
-    bucket_name = "meta-morph"
+    bucket_name = "meta-morph-flow"
     bucket = storage_client.bucket(bucket_name)
     destination_blob_name = f"{today}/{type_of_data}_{today}.csv"
     blob = bucket.blob(destination_blob_name)
@@ -191,7 +191,7 @@ def files_check():
     client = storage.Client.from_service_account_json(SERVICE_KEY)
 
     # List files in the bucket
-    bucket = client.get_bucket("meta-morph")
+    bucket = client.get_bucket("meta-morph-flow")
     blobs = bucket.list_blobs()
     server_ready = False
 
@@ -225,11 +225,11 @@ def generate_token():
     token = create_access_token(data)
     return {"access_token": token}
 
-# suppliers API to fetch the latest supplier data from the meta-morph bucket
+# suppliers API to fetch the latest supplier data from the meta-morph-flow bucket
 @app.get("/v1/suppliers")
 async def load_suppliers_data():
 
-    df = pd.read_csv(f"gs://meta-morph/{today}/supplier_{today}.csv", 
+    df = pd.read_csv(f"gs://meta-morph-flow/{today}/supplier_{today}.csv", 
                         storage_options={
                             "token": SERVICE_KEY
                         }
@@ -238,11 +238,11 @@ async def load_suppliers_data():
     supplier_result = df.reset_index().to_dict(orient="records")
     return {"status" : 200, "data" : supplier_result}
 
-# products API to fetch the latest product data from the meta-morph bucket
+# products API to fetch the latest product data from the meta-morph-flow bucket
 @app.get("/v1/products")
 async def load_products_data():
 
-    df = pd.read_csv(f"gs://meta-morph/{today}/product_{today}.csv", 
+    df = pd.read_csv(f"gs://meta-morph-flow/{today}/product_{today}.csv", 
                         storage_options={
                             "token": SERVICE_KEY
                         }
@@ -251,11 +251,11 @@ async def load_products_data():
     product_result = df.reset_index().to_dict(orient="records")
     return {"status" : 200, "data" : product_result}
 
-# customers API to fetch the latest customer data from the meta-morph bucket
+# customers API to fetch the latest customer data from the meta-morph-flow bucket
 @app.get("/v1/customers")
 async def load_customer_data(payload: dict = Depends(verify_token)):
     df = pd.read_csv(
-        f"gs://meta-morph/{today}/customer_{today}.csv",
+        f"gs://meta-morph-flow/{today}/customer_{today}.csv",
         storage_options={"token": SERVICE_KEY}
     ).set_index("Customer Id")
 

--- a/raptor/Raptor/Raptor.py
+++ b/raptor/Raptor/Raptor.py
@@ -76,7 +76,7 @@ def _get_gcs_data(spark, reporting_file, sql):
     df = spark.read.format("parquet") \
                 .option('header', 'True') \
                 .option('inferSchema','True') \
-                .load(f'gs://reporting-legacy/{reporting_file}')
+                .load(f'gs://reporting-lgcy/{reporting_file}')
     logging.info("Connection established with the reporting bucket..")
     df.createOrReplaceTempView(f"{reporting_file}")
     logging.info("Returned the Data from reporting..")


### PR DESCRIPTION
As a part of the story : [MM-88](https://trello.com/c/wAsLDF1H/88-admin-migration-to-new-gcp-account-update-secrets-and-bucket-reference), We are changing the GCP to new account for which : 
- Update GCP Credentials
- Replace the old GCP credentials in all Airflow tasks and Rest APIs
- The bucket name has changed from meta-morph ➜ meta-morph-flow.
- Ensure all existing services and data workflows continue functioning with the new credentials and bucket.

Success Snapshot: 
![image](https://github.com/user-attachments/assets/28480d9b-988d-4b4f-9447-20d5a02739f1)
