### PR TITLE
fix added to avoid wrong percentiles

### DIFF
--- a/ETL-Airflow/dags/tasks/m_customer_sales_report_task.py
+++ b/ETL-Airflow/dags/tasks/m_customer_sales_report_task.py
@@ -130,9 +130,9 @@ def customer_sales_report_ingestion():
     logging.info(f"Data Frame : 'AGG_TRANS_Customer' is built...")
     
     # Calculate the limits of the tier level
-    max_value = AGG_TRANS_Customer.select(round(max("sum_sales_amount"), 2).alias("max_sales_amount")).collect()[0][0]
-    gold_tier = max_value * 80/100
-    silver_tier = max_value * 50 / 100
+    quantiles = AGG_TRANS_Customer.approxQuantile("sum_sales_amount", [0.5, 0.8], 0.01)
+    silver_tier = quantiles[0] 
+    gold_tier = quantiles[1]
 
     # Process the Node : EXP_Customer_Sales_Report - Add the Loyalty_Tier column
     EXP_Customer_Sales_Report = AGG_TRANS_Customer \


### PR DESCRIPTION
As a part of the story [MM-83](https://trello.com/c/S0zqGc0w/83-admin-records-getting-dropped-in-customer-sales-report) : 
- Fixed the issue of Calculating the wrong percentile..

Success Screenshot : 
![image](https://github.com/user-attachments/assets/fb78278a-141e-4ed7-9b1d-4a7c3e21ce9e)
