### PR TITLE
Posted Fix of the Product name populated for no revenue

### DIFF
--- a/ETL-Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL-Airflow/dags/tasks/m_supplier_performance_task.py
@@ -116,6 +116,14 @@ def suppliers_performance_ingestion():
                                         "rnk", row_number().over(window_spec)
                                     ) \
                                     .filter("rnk = 1") \
+                                    .withColumn(
+                                        "product_name",
+                                        when(
+                                            col("agg_total_revenue") > 0
+                                            , col("product_name")
+                                        ) \
+                                        .otherwise(lit(None).cast("string"))
+                                    ) \
                                     .drop(col("rnk")) \
                                     .withColumn("day_dt", current_date())
     logging.info("Data Frame : 'EXP_Suppliers_Performance' is built...")


### PR DESCRIPTION
As a part of the bug: [MM-62](https://trello.com/c/Ci2B46Gl/62-admin-%F0%9F%94%8D-investigate-why-topsellingproduct-is-populated-even-though-totalrevenue-is-0-in-supplierperformance-table) : 
- The TOP_SELLING_PRODUCT field is not being populated when the TOTAL_REVENUE is 0.

Screenshot : 
![image](https://github.com/user-attachments/assets/949727f4-3548-4c77-97d8-6ad031196bd1)
![image](https://github.com/user-attachments/assets/b1c7591c-fe34-43cd-a66f-9a7fc5a85ee8)
