### PR TITLE
Fix/ MM-149

### DIFF
--- a/ETL-Airflow/dags/tasks/m_pull_work_to_pgadmin.py
+++ b/ETL-Airflow/dags/tasks/m_pull_work_to_pgadmin.py
@@ -3,6 +3,7 @@ from .my_secrets import SERVICE_KEY
 from tasks.utils import get_list_of_tables, get_spark_session, write_into_table
 from google.cloud import storage
 import logging
+from pyspark.errors import AnalysisException
 
 
 def list_files_to_load():
@@ -29,9 +30,17 @@ def process_single_file(file: str):
     Consumes the files from the File list one by one and loads into table
     """
     spark = get_spark_session()
-    df = spark.read.format("parquet").load(f"gs://raptor-workflow/{file}")
-    table_name = file.split('/')[1].split('.')[-1]
-    write_into_table(table_name, df, 'work', 'overwrite')
+    try:
+        df = spark.read.format("parquet").load(f"gs://raptor-workflow/{file}")
+        if df.count() == 0:
+            logging.info(f"Skipping {file}")
+        else:
+            logging.info(f"Processing {file}")
+            table_name = file.split('/')[1].split('.')[-1]
+            write_into_table(table_name, df, 'work', 'overwrite')
+    except AnalysisException as e:
+        logging.info(f"Skipping Temp parquet File with exception{str(e)}..!")
+    return f"{file} successfully pulled into Local postgres"
 
 
 @task(task_id="m_pull_files")


### PR DESCRIPTION
Fixing the bug mentioned in: [MM-149](https://trello.com/c/MLrzh7Dy/149-admin-fix-pulldatatopgadmin-task-to-robustly-sync-raptor-datasets-from-gcs-to-local-postgres)
- The local Postgres DB remains in sync with all Raptor-generated datasets.
- It logs and skips for datasets that have no records.
- It skips temporary files or irrelevant artifacts present in GCS.