### PR TITLE
flake8 standardisation

### DIFF
--- a/ETL-Airflow/dags/adhoc_reload_metamorph_pipeline.py
+++ b/ETL-Airflow/dags/adhoc_reload_metamorph_pipeline.py
@@ -5,7 +5,16 @@ from airflow.utils.task_group import TaskGroup
 from datetime import datetime
 import pytz
 import os
-from tasks.adhoc.adhoc_reload_tables_task import *
+from tasks.adhoc.adhoc_reload_tables_task import (
+    supplier_data_ingestion,
+    customer_data_ingestion,
+    products_data_ingestion,
+    sales_data_ingestion,
+    suppliers_performance_ingestion,
+    customer_sales_report_ingestion,
+    product_performance_ingestion
+)
+
 
 # Date/count generator
 def freq(today):
@@ -13,6 +22,7 @@ def freq(today):
     for idx, i in enumerate(range(today, today + 5)):
         result.append((str(i), 4 - idx))
     return result
+
 
 @dag(
     dag_id='adhoc_reload_metamorph',
@@ -52,5 +62,6 @@ def ingestion():
         if prev_group:
             prev_group >> group
         prev_group = group
+
 
 ingestion()

--- a/ETL-Airflow/dags/meta_morph_etl.py
+++ b/ETL-Airflow/dags/meta_morph_etl.py
@@ -60,7 +60,6 @@ def ingestion():
         {"env": env, "table_name": table} for table in TABLES
     ])
 
-
     # Set the Tasks Dependency
     for upstream in [suppliers, customers, products, sales]:
         for downstream in [supplier_performance,

--- a/ETL-Airflow/dags/tasks/adhoc/adhoc_MM_148_20250711.py
+++ b/ETL-Airflow/dags/tasks/adhoc/adhoc_MM_148_20250711.py
@@ -5,7 +5,6 @@ from tasks.utils import (
     abort_session,
     get_spark_session
 )
-from pyspark.sql.functions import col, current_date
 
 
 @task(task_id="m_load_legacy_tables_to_gcs")

--- a/ETL-Airflow/dags/tasks/adhoc/adhoc_env_test.py
+++ b/ETL-Airflow/dags/tasks/adhoc/adhoc_env_test.py
@@ -5,11 +5,12 @@ from tasks.utils import (
     get_spark_session
 )
 
+
 @task
 def test_environment(env):
-    if env == 'prod':   
+    if env == 'prod':
         logging.info('PRODUCTION Environment')
-    else :
+    else:
         logging.info('DEVELOPMENT Environment')
     try:
         spark = get_spark_session()
@@ -19,4 +20,4 @@ def test_environment(env):
         raise
     finally:
         abort_session(spark)
-    return f"Successfully fetched.."
+    return "Successfully fetched.."

--- a/ETL-Airflow/dags/tasks/adhoc/adhoc_reload_tables_task.py
+++ b/ETL-Airflow/dags/tasks/adhoc/adhoc_reload_tables_task.py
@@ -2,7 +2,6 @@
 # Import libraries
 from airflow.decorators import task
 from pyspark.sql import Row
-from pyspark.sql.functions import current_date, col
 import logging
 from tasks.utils import (
     get_spark_session,
@@ -60,7 +59,7 @@ def supplier_data_ingestion(env, date, count):
 
     # Populating the legacy version of Suppliers Data
     suppliers_df_lgcy = suppliers_df \
-        .withColumn("DAY_DT", current_date() -  count) \
+        .withColumn("DAY_DT", current_date() - count) \
         .select(
             col("DAY_DT"),
             col("SUPPLIER_ID"),
@@ -539,7 +538,6 @@ def suppliers_performance_ingestion(env, date, cnt):
     return "supplier_performance data ingested successfully!"
 
 
-
 # Create a task that helps in populating Products_Performance
 @task(task_id="m_load_products_performance")
 def product_performance_ingestion(env, date, cnt):
@@ -788,7 +786,7 @@ def customer_sales_report_ingestion(env, date, cnt):
             col("top_selling_product")
         ) \
         .filter(
-            (col("day_dt") == current_date()) &
+            (col("day_dt") == current_date() - cnt) &
             (col("top_selling_product").isNotNull())
         ).distinct()
     data_list = SQ_Shortcut_To_Supplier_Performance.collect()
@@ -861,7 +859,7 @@ def customer_sales_report_ingestion(env, date, cnt):
                     ) \
         .withColumn("sale_date",
                     coalesce(
-                        col("sale_date"), current_date() - 1
+                        col("sale_date"), current_date() - cnt - 1
                     )) \
         .withColumn("sale_year",
                     year(col("sale_date"))

--- a/ETL-Airflow/dags/tasks/m_customer_metrics_task.py
+++ b/ETL-Airflow/dags/tasks/m_customer_metrics_task.py
@@ -274,7 +274,10 @@ def customer_metrics_upsert(env):
             schema=staging,
             strategy="overwrite"
         )
-        execute_merge(f"{staging}.customer_metrics_stg", f"{legacy}.CUSTOMER_METRICS")
+        execute_merge(
+            f"{staging}.customer_metrics_stg",
+            f"{legacy}.CUSTOMER_METRICS"
+        )
 
     except Exception as e:
 

--- a/ETL-Airflow/dags/tasks/utils.py
+++ b/ETL-Airflow/dags/tasks/utils.py
@@ -28,7 +28,7 @@ class APIClient:
         self.base_url = base_url
 
     # Define a method to fetch the data when the API is called
-    def fetch_data(self, api_type: str, auth=False, _date: str=None):
+    def fetch_data(self, api_type: str, auth=False, _date=None):
         """
         Fetches data from the API Endpoint.
 
@@ -109,7 +109,9 @@ class DuplicateChecker:
         Duplicate Exception if the Duplicates are found.
         """
         logging.info("Checking for the duplicates in the provided Dataset")
-        grouped_df = df.repartition(4, *primary_key_list).groupBy(primary_key_list) \
+        grouped_df = df.repartition(
+            4, *primary_key_list
+        ).groupBy(primary_key_list) \
             .agg(count('*').alias('cnt'))\
             .filter('cnt > 1')
         if grouped_df.limit(1).count() > 0:
@@ -159,18 +161,18 @@ def fetch_env_schema(env):
     if env == 'prod':
         logging.info('PRODUCTION Environment..!')
         result = {
-            "raw" : "raw",
-            "legacy" : "legacy",
-            "staging" : "staging",
-            "gcs_legacy" : "gs://reporting-lgcy"
+            "raw": "raw",
+            "legacy": "legacy",
+            "staging": "staging",
+            "gcs_legacy": "gs://reporting-lgcy"
         }
     else:
         logging.info('DEVELOPMENT Environment..!')
         result = {
-            "raw" : "dev_raw",
-            "legacy" : "dev_legacy",
-            "staging" : "dev_staging",
-            "gcs_legacy" : "gs://dev-reporting-lgcy"
+            "raw": "dev_raw",
+            "legacy": "dev_legacy",
+            "staging": "dev_staging",
+            "gcs_legacy": "gs://dev-reporting-lgcy"
         }
     return result
 
@@ -253,8 +255,11 @@ def write_to_gcs(dataframe, gcs_path, location):
     dataframe (Dataframe): The Spark Dataframe which we want to write
     location (String): The target GCS Location where to write
     """
-    logging.info(f"Authenticating to {gcs_path} to load the data into parquet file..")
-    dataframe.repartition(2).write.mode("append").parquet(f"{gcs_path}/{location}")
+    logging.info(
+        f"Authenticating to {gcs_path} to load the data into parquet file.."
+    )
+    dataframe.repartition(2)\
+        .write.mode("append").parquet(f"{gcs_path}/{location}")
     logging.info(f"Loaded into Parquet File : {location}")
 
 

--- a/Rest-API/main.py
+++ b/Rest-API/main.py
@@ -345,6 +345,7 @@ async def load_customer_data(payload: dict = Depends(verify_token)):
     customer_result = df.reset_index().to_dict(orient="records")
     return {"status": 200, "data": customer_result}
 
+
 # suppliers API to fetch the latest supplier data from the bucket
 @app.get("/v2/suppliers")
 async def load_suppliers_data_v2(


### PR DESCRIPTION
Implementation of flake8 standardisation as per the story, [MM-169](https://trello.com/c/H1JZ41A7/169-use-flake8-standards-testing-for-adhocreloadpipeline-dag-post-deployment-with-prod-data):
- Test full 5-day reload for each endpoint (/v1/suppliers, /v1/products, /v1/customers) using production dataset.
- Validated row counts and checksums between source and destination for integrity.
- Checked idempotency: re-running the DAG with same dates did not duplicate records.
- Confirmed logs, captured fetch success/failure per date and per dataset.

Lower Env Success Screenshots:
a. Meta_morph_Pipeline : 
<img width="1365" height="668" alt="image" src="https://github.com/user-attachments/assets/7979ba47-289b-4d0f-ba4e-30d7219cd1a6" />

b. adhoc_Reload_metamorph:
<img width="1365" height="668" alt="image" src="https://github.com/user-attachments/assets/d640265b-725c-4daa-9366-a1243fbde7d2" />

c. Raptor Success Screenshots:
Supplier Performance : 
<img width="1141" height="537" alt="image" src="https://github.com/user-attachments/assets/1e4d0c68-e88e-4ea0-8716-e761b335aec3" />

Products Performance : 
<img width="1161" height="560" alt="image" src="https://github.com/user-attachments/assets/e319ddac-a476-4580-9897-a0714105d50b" />

Customer_sales_report:
<img width="1151" height="543" alt="image" src="https://github.com/user-attachments/assets/15980d60-ddff-4005-8fca-42507b678c58" />


